### PR TITLE
avoid large object retrieval from database

### DIFF
--- a/src/ConnectionFromMongoCursor.js
+++ b/src/ConnectionFromMongoCursor.js
@@ -170,7 +170,10 @@ const connectionFromMongoCursor = async ({
   cursor.skip(skip);
   cursor.limit(limit);
 
-  const slice = await cursor.exec();
+  //avoid large object retrieval from database
+  const clonedCursor = cursor.find().merge(cursor).select({ _id: 1 })
+
+  const slice = await clonedCursor.exec();
 
   const edges = slice.map((value, index) => ({
     cursor: offsetToCursor(startOffset + index),


### PR DESCRIPTION
If the collections in mongoDB contains very large documents, the await cursor.exec() can be slow. Projecting only the id may improve performances.

Bye!