### PR TITLE
Fix incorrect object key in call to getTotalCount

### DIFF
--- a/src/ConnectionFromMongoCursor.js
+++ b/src/ConnectionFromMongoCursor.js
@@ -149,7 +149,7 @@ const connectionFromMongoCursor = async ({
   const clonedCursor = cursor.model.find().merge(cursor);
 
   const totalCount = await getTotalCount({
-    clonedCursor,
+    cursor: clonedCursor,
   });
 
   const {


### PR DESCRIPTION
The function getTotalCount accepts a `cursor` key and not `clonedCursor`. Fixes #8.