### PR TITLE
Fix bug when result set is empty, limit would be 0 and not work with $slice

### DIFF
--- a/src/__tests__/ConnectionFromMongoCursor.spec.js
+++ b/src/__tests__/ConnectionFromMongoCursor.spec.js
@@ -61,3 +61,55 @@ it('should return connection from mongo cursor', async () => {
   expect(loader.mock.calls[3]).toEqual([context, userD._id]);
   expect(resultSecondPage).toMatchSnapshot();
 });
+
+it('should work with empty args', async () => {
+  const userA = await createUser();
+  await createUser();
+  await createUser();
+  await createUser();
+
+  const cursor = UserModel.find();
+  const context = {
+    // got it throwing a 🎲
+    randomValue: 2,
+  };
+
+  const loader = jest.fn();
+  loader.mockReturnValue('user');
+
+  const args = {};
+
+  const result = await connectionFromMongoCursor({
+    cursor,
+    context,
+    args,
+    loader,
+  });
+
+  expect(loader).toHaveBeenCalledTimes(4);
+  expect(loader.mock.calls[0]).toEqual([context, userA._id]);
+  expect(result).toMatchSnapshot();
+});
+
+it('should work with empty args and empty result', async () => {
+  const cursor = UserModel.find();
+  const context = {
+    // got it throwing a 🎲
+    randomValue: 2,
+  };
+
+  const loader = jest.fn();
+  loader.mockReturnValue('user');
+
+  const args = {};
+
+  const result = await connectionFromMongoCursor({
+    cursor,
+    context,
+    args,
+    loader,
+  });
+
+  expect(loader).not.toHaveBeenCalled();
+  expect(result).toMatchSnapshot();
+});

--- a/src/__tests__/__snapshots__/ConnectionFromMongoAggregate.spec.js.snap
+++ b/src/__tests__/__snapshots__/ConnectionFromMongoAggregate.spec.js.snap
@@ -39,3 +39,42 @@ Object {
   "startCursorOffset": 1,
 }
 `;
+
+exports[`should work with empty args 1`] = `
+Object {
+  "count": 2,
+  "edges": Array [
+    Object {
+      "cursor": "bW9uZ286MA==",
+      "node": "user",
+    },
+    Object {
+      "cursor": "bW9uZ286MQ==",
+      "node": "user",
+    },
+  ],
+  "endCursorOffset": 2,
+  "pageInfo": Object {
+    "endCursor": "bW9uZ286MQ==",
+    "hasNextPage": false,
+    "hasPreviousPage": false,
+    "startCursor": "bW9uZ286MA==",
+  },
+  "startCursorOffset": 0,
+}
+`;
+
+exports[`should work with empty args and empty result 1`] = `
+Object {
+  "count": 0,
+  "edges": Array [],
+  "endCursorOffset": 0,
+  "pageInfo": Object {
+    "endCursor": null,
+    "hasNextPage": false,
+    "hasPreviousPage": false,
+    "startCursor": null,
+  },
+  "startCursorOffset": 0,
+}
+`;

--- a/src/__tests__/__snapshots__/ConnectionFromMongoCursor.spec.js.snap
+++ b/src/__tests__/__snapshots__/ConnectionFromMongoCursor.spec.js.snap
@@ -47,3 +47,50 @@ Object {
   "startCursorOffset": 2,
 }
 `;
+
+exports[`should work with empty args 1`] = `
+Object {
+  "count": 4,
+  "edges": Array [
+    Object {
+      "cursor": "bW9uZ286MA==",
+      "node": "user",
+    },
+    Object {
+      "cursor": "bW9uZ286MQ==",
+      "node": "user",
+    },
+    Object {
+      "cursor": "bW9uZ286Mg==",
+      "node": "user",
+    },
+    Object {
+      "cursor": "bW9uZ286Mw==",
+      "node": "user",
+    },
+  ],
+  "endCursorOffset": 4,
+  "pageInfo": Object {
+    "endCursor": "bW9uZ286Mw==",
+    "hasNextPage": false,
+    "hasPreviousPage": false,
+    "startCursor": "bW9uZ286MA==",
+  },
+  "startCursorOffset": 0,
+}
+`;
+
+exports[`should work with empty args and empty result 1`] = `
+Object {
+  "count": 0,
+  "edges": Array [],
+  "endCursorOffset": 0,
+  "pageInfo": Object {
+    "endCursor": null,
+    "hasNextPage": false,
+    "hasPreviousPage": false,
+    "startCursor": null,
+  },
+  "startCursorOffset": 0,
+}
+`;


### PR DESCRIPTION
Mongoose Aggregate.limit/skip, internally, adds a `$slice` pipeline to the Aggregate, and $slice does not work with values `<= 0`.
